### PR TITLE
fix: exclude test files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+tests/
+.github/
+.git/
+tsconfig.json
+package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-sitemap-generator",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "angular-sitemap-generator",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-sitemap-generator",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Generates a sitemap.xml file for Angular projects",
   "keywords": [
     "sitemap",


### PR DESCRIPTION
Fixes #2

Added `.npmignore` to exclude `tests/`, `.github/`, `tsconfig.json`, and `package-lock.json` from the published package. This significantly reduces install size since the test fixtures include full Angular project scaffolds.