### PR TITLE
Fix: README documentation and workflow permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   id-token: write
-  contents: write
+  contents: read
 
 jobs:
   get-next-prerelease:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ project-root/
 - You can specify custom paths for both the sitemap, robots, and MPA directories.
 - Use `--gen-robots` to create a new `robots.txt`, or `--update-robots` to update an existing one.
 - Use `--create-mpa-dir` to generate static directories for each route (fixing 404 errors on GitHub Pages).
-- Compatible with **Angular 15+** projects using standalone route definitions.
+- Compatible with **Angular 18+** projects using standalone route definitions.
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/borisonekenobi/angular-sitemap-generator/issues/4 & https://github.com/borisonekenobi/angular-sitemap-generator/issues/6

Updated supported Angular versions from 15+ to 18+ in `README.md`

Removed unnecessary write permissions from `workflow.yml`