### PR TITLE
feat: add .npmignore to exclude unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+tests/
+.github/
+.git/
+package-lock.json


### PR DESCRIPTION
Fixes https://github.com/borisonekenobi/angular-sitemap-generator/issues/2

Added `.npmignore` to exclude `tests/`, `.github/`, and `package-lock.json` from the published package. This significantly reduces install size since the test fixtures include full Angular project scaffolds.