### PR TITLE
feat: add .gitattributes to mark test files as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/** linguist-vendored


### PR DESCRIPTION
Fixes: #11 

This pull request makes a small configuration change to the repository by updating the `.gitattributes` file. The change marks all files in the `tests` directory as "linguist-vendored," which means GitHub will treat them as vendored code and exclude them from language statistics and search results.